### PR TITLE
SIANXSVC-1192: Updated GitHub action path in the publish action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,6 @@ jobs:
     if: github.actor != 'dependabot[bot]'
 
     steps:
-      - uses: anexia-it/go.anx.io@main
+      - uses: anexia/go.anx.io@main
         env:
           GOANXIO_E5E_TOKEN: "${{ secrets.GOANXIO_E5E_TOKEN }}"

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ func main() {
 
 * Andreas Stocker <AStocker@anexia-it.com>, Lead Developer
 * Patrick Taibel <PTaibel@anexia-it.com>, Developer
-* Jasmin Oster <joster@anexia.com>, Developer
+* Jasmin Oster <JOster@anexia.com>, Developer
 
 ## Links
 


### PR DESCRIPTION
go.anx.io moved to the "anexia" GitHub organisation. Updated the publish action accordingly in this PR.