### PR TITLE
SIANXSVC-1214: Replace codecov with codeclimate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,5 +39,18 @@ jobs:
         run: go vet ./...
       - name: Run Go test
         run: go test -v -race -coverprofile=coverage.txt -covermode=atomic ./...
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+
+        # Because the module path differs from the path, we have to to remove the prefix from
+        # the cover file. See also:
+        # https://github.com/paambaati/codeclimate-action/issues/109#issuecomment-751311299
+      - name: Adjust code coverage report for CodeClimate
+        run: |
+          export GO_MODULE_NAME=$(go mod edit -json | jq -r '.Module.Path')
+          sed -i "s%$GO_MODULE_NAME/%%" coverage.txt
+
+      - name: Upload coverage to CodeClimate
+        uses: paambaati/codeclimate-action@v5
+        env:
+          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
+        with:
+          coverageLocations: "coverage.txt:gocov"

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ go-e5e
 
 [![PkgGoDev](https://pkg.go.dev/badge/go.anx.io/e5e/v2)](https://pkg.go.dev/go.anx.io/e5e/v2)
 [![Build Status](https://github.com/anexia/go-e5e/actions/workflows/test.yml/badge.svg?branch=main&event=push)](https://github.com/anexia/go-e5e/actions/?query=workflow%3Atest)
-[![codecov](https://codecov.io/gh/anexia/go-e5e/branch/main/graph/badge.svg)](https://codecov.io/gh/anexia/go-e5e)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/4707b867d2cb4052797e/test_coverage)](https://codeclimate.com/github/anexia-it/go-e5e/test_coverage)
 [![Go Report Card](https://goreportcard.com/badge/go.anx.io/e5e/v2)](https://goreportcard.com/report/go.anx.io/e5e/v2)
 
 go-e5e is a support library to help Go developers build Anexia e5e functions.


### PR DESCRIPTION
Unfortunately, the badge URL contains the ID of the project which does not seem to be publicly available. So, as of right now, the badge in the README would not work and therefore got removed.

@beachmachine: Please change the default branch on CodeClimate to `main`, it still seems to assume that `master` is the default.
